### PR TITLE
Cleanup

### DIFF
--- a/pkg/metrics/sync.go
+++ b/pkg/metrics/sync.go
@@ -36,9 +36,6 @@ func Sync(ctx context.Context, tmc *TendermintClient, st *Store) (uint, error) {
 			// BUG this can happen when the commit does not exist.
 			// There is no sane way to distinguish this case from
 			// any other tendermint API error.
-			// Commit(ctx, tmc, -1) can be used to get the latest
-			// commit.
-
 			return inserted, errors.Wrapf(err, "blocks for %d", syncedHeight+1)
 		}
 		syncedHeight = c.Height


### PR DESCRIPTION
This contains two changes mentioned in the previous pull request

- validator address -> database ID caching is extracted to not obfuscate the business logic
- tendermint client was updated to be a proper JSONPRC client that supports concurrency. I have tried [`net/jsonrcp`](https://golang.org/pkg/net/rpc/jsonrpc/) first but the end implementation was neither cleaner nor working :rofl: Gorilla websocket does not explicitly supports `io.ReadWriteCloser` interface which is required by `net/jsonrpc`.