### PR TITLE
Fix up the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Requires go1.11+
 
+You must also `export GO111MODULE=on` in your environment to use the go modules feature.
+
 # Run locally
 
 For local development you can use a local Postgres instance and any Tendermint
@@ -11,6 +13,7 @@ $ docker run -it --rm -e POSTGRES_PASSWORD='' -p 5432:5432 postgres:alpine
 
 # Run collector. Default configuration is expected to work for local
 # development. If needed it can be changed via environment variables.
-$ TENDERMINT_RPC="TODO" \
+$ TENDERMINT_WS_URI="wss://bns.hugnet.iov.one/websocket" \
+  POSTGRES_URI="postgresql://postgres@localhost:5432" \
     go run cmd/collector/main.go
 ```


### PR DESCRIPTION
Closes #6 

This makes the code work and complete. So you can just run it without digging through the code and google to see what is expected.

Default cli example will sync all blocks from hugnet to show multiple validators.

