### PR TITLE
Fix message detail

### DIFF
--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS transactions (
 	id BIGSERIAL PRIMARY KEY,
 	transaction_hash BYTEA NOT NULL,
 	block_id BIGINT NOT NULL REFERENCES blocks(block_height),
-	message TEXT 
+	message JSONB
 );
 
 CREATE INDEX ON transactions (transaction_hash);

--- a/pkg/metrics/sync.go
+++ b/pkg/metrics/sync.go
@@ -149,8 +149,8 @@ func Sync(ctx context.Context, tmc *TendermintClient, st *Store) (uint, error) {
 }
 
 type Message struct {
-	Path    string `json:"path"`
-	Details string `json:"details"`
+	Path    string          `json:"path"`
+	Details json.RawMessage `json:"details"`
 }
 
 func messageDetails(msg weave.Msg) (string, error) {
@@ -170,7 +170,7 @@ func messageDetails(msg weave.Msg) (string, error) {
 			}
 			messages[k] = Message{
 				Path:    v.Path(),
-				Details: string(details),
+				Details: json.RawMessage(details),
 			}
 		}
 
@@ -185,7 +185,7 @@ func messageDetails(msg weave.Msg) (string, error) {
 		res, err := json.Marshal(
 			Message{
 				Path:    message.Path(),
-				Details: string(details)})
+				Details: json.RawMessage(details)})
 		return string(res), err
 	}
 }


### PR DESCRIPTION
On the current version, message details are put in the database with double quotes at the beginning of every element: 

```json
{"path":"cash/send","details":"{\"metadata\":{\"schema\":1},\"source\":\"E774B6E08E3C9AD9D35A7830654DB7906B0B02D5\",\"destination\":\"C1721181E83376EF978AA4A9A38A5E27C08C7BB2\",\"amount\":{\"whole\":1,\"ticker\":\"IOV\"},\"memo\":\"Hello world! Congratulations to the team in Osaka. Hurray\"}"}
```
With this PR,  the output is :
```json
{"path":"cash/send","details":{"metadata":{"schema":1},"source":"E774B6E08E3C9AD9D35A7830654DB7906B0B02D5","destination":"C1721181E83376EF978AA4A9A38A5E27C08C7BB2","amount":{"whole":1,"ticker":"IOV"},"memo":"Hello world! Congratulations to the team in Osaka. Hurray"}}
```

We make sure `jsonb` format is not violated.